### PR TITLE
Gremlin server 3.3.0 has issues with this setup. 3.2.6 works fine. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,16 @@ RUN apk update && \
 	apk add wget unzip git bash
 
 # Install the server
-RUN wget --no-check-certificate -O /gremlin.zip http://apache.mirrors.ovh.net/ftp.apache.org/dist/tinkerpop/3.3.0/apache-tinkerpop-gremlin-server-3.3.0-bin.zip && \
+RUN wget --no-check-certificate -O /gremlin.zip http://apache.mirrors.ovh.net/ftp.apache.org/dist/tinkerpop/3.2.6/apache-tinkerpop-gremlin-server-3.2.6-bin.zip && \
 	unzip /gremlin.zip -d /gremlin && \
 	rm /gremlin.zip
-WORKDIR /gremlin/apache-tinkerpop-gremlin-server-3.3.0
+WORKDIR /gremlin/apache-tinkerpop-gremlin-server-3.2.6
 
 # Place where the graph is saved, see gremlin-graph.properties
 RUN mkdir /graph_file
 
 # Configure gremlin for python
-RUN bin/gremlin-server.sh -i org.apache.tinkerpop gremlin-python 3.3.0
+RUN bin/gremlin-server.sh -i org.apache.tinkerpop gremlin-python 3.2.6
 
 EXPOSE 8182
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ Alternatively, you can pull the image from DockerHub [here](https://hub.docker.c
 
 
 A demo showing how to access the database with python is provided. 
-Python 3 is required as well as the gremlin-python module. This module can be installed using:
+Python 3 is required as well as the gremlin-python module (use the version 
+that matches the gremlin-server version.) This 
+module 
+can be installed using:
 ```
-pip install gremlinpython
+pip install gremlinpython==3.2.6
 ```
 To run the demo, simply write in the console:
 ```


### PR DESCRIPTION
This merge fixes an issue with my previous PR (apologies!). Also added clarification to the README that gremlinpython should be the same version as gremlin-server.