### PR TITLE
update dockerfile and readme for tinkerpop 3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,16 +8,16 @@ RUN apk update && \
 	update-ca-certificates
 
 # Install the server
-RUN wget -O /gremlin.zip http://mirror.cc.columbia.edu/pub/software/apache/tinkerpop/3.3.3/apache-tinkerpop-gremlin-server-3.3.3-bin.zip && \
+RUN wget -O /gremlin.zip http://mirror.cc.columbia.edu/pub/software/apache/tinkerpop/3.4.0/apache-tinkerpop-gremlin-server-3.4.0-bin.zip && \
 	unzip /gremlin.zip -d /gremlin && \
 	rm /gremlin.zip
-WORKDIR /gremlin/apache-tinkerpop-gremlin-server-3.3.3
+WORKDIR /gremlin/apache-tinkerpop-gremlin-server-3.4.0
 
 # Place where the graph is saved, see gremlin-graph.properties
 RUN mkdir /graph_file
 
 # Configure gremlin for python
-RUN bin/gremlin-server.sh install org.apache.tinkerpop gremlin-python 3.3.3
+RUN bin/gremlin-server.sh install org.apache.tinkerpop gremlin-python 3.4.0
 
 EXPOSE 8182
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Docker container for Gremlin 3.x
 
-*There are different releases in this repository for version 3.2.4, 3.2.5, 3.2.6, 3.3.0, 3.3.2, and 3.3.3 of Gremlin. Check the [releases](https://github.com/bricaud/gremlin-server/releases). The latest is for v3.3.3.*
+*There are different releases in this repository for version 3.2.4, 3.2.5, 3.2.6, 3.3.0, 3.3.2, 3.3.3, and 3.4.0 of Gremlin. Check the [releases](https://github.com/bricaud/gremlin-server/releases). The latest is for v3.4.0.*
 
 This Docker file creates a container running [Gremlin Tinkerpop](https://github.com/apache/tinkerpop), with a TinkerGraph and configured for use with Python ([gremlin-python](http://tinkerpop.apache.org/docs/current/reference/#gremlin-python)).
 To build it, run the following command:
@@ -30,7 +30,7 @@ can be installed using:
 ```
 pip install gremlinpython==3.a.b
 ```
-where `a` and `b` are the sub-version number. It can be 3.2.4, 3.2.5, 3.2.6, 3.3.0, 3.3.2, or 3.3.3
+where `a` and `b` are the sub-version number. It can be 3.2.4, 3.2.5, 3.2.6, 3.3.0, 3.3.2, 3.3.3, or 3.4.0
 
 To run the demo (and make a minimal test), simply write in the console:
 ```


### PR DESCRIPTION
updated tinkerpop and gremlin-python to the latest version (3.4.0). `test_graph.py` seemed to work fine (installed under my py3.7 virtual environment)